### PR TITLE
Bumping `human-panic` dependency to 1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.1.2-alpha.0"
 
 [dependencies]
 failure = "0.1.1"
-human-panic = "0.4.0"
+human-panic = "1.0.0"
 log = "0.4.1"
 serde = "1.0.58"
 serde_derive = "1.0.58"


### PR DESCRIPTION
This way you will get backwards compatible updates automatically via `cargo update` :slightly_smiling_face: 